### PR TITLE
Add GetHTTPClient

### DIFF
--- a/victorops/victorops.go
+++ b/victorops/victorops.go
@@ -100,3 +100,8 @@ func NewConfigurableClient(apiID string, apiKey string, publicBaseURL string, ar
 
 	return &client
 }
+
+// GetHTTPClient returns http client for the purpose of test
+func (c Client) GetHTTPClient() *http.Client {
+	return &c.httpClient
+}

--- a/victorops/victorops_test.go
+++ b/victorops/victorops_test.go
@@ -49,6 +49,9 @@ func TestConfigurableClient(t *testing.T) {
 
 	testConfigurableClient := NewConfigurableClient("apiID", "apiKey", testServer.URL, args)
 	log.Printf("Client instantiated: %s", testConfigurableClient.publicBaseURL)
+	if testConfigurableClient.GetHTTPClient() == nil {
+		t.Errorf("http client is nil")
+	}
 }
 
 func TestConfigurableClientTimeout(t *testing.T) {


### PR DESCRIPTION
Introduce GetHTTPClient() function to return http client for test purposes. http client can be intercepted and uses for mock for unit test